### PR TITLE
Don't fail when there is no .kube dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ Reproducible infrastructure to showcase GitOps workflows. Derived from our [cons
 
 ## Prerequisites
 
-To be able to set up the infrastructure you are required to have **kubectl**, **k3s** and **helm** set up.
-If you use the provided script, these components will be installed, if not done yet.
-
+To be able to set up the infrastructure you need a linux machine (tested with Ubuntu 20.04) with docker installed.
+All other tools like kubectl, k3s and helm are set up using the `./scripts/init-cluster.sh` script.
 
 ## Install k3s
 

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -11,8 +11,10 @@ HELM_BINARY_NAME='helm'
 KUBECTL_VERSION=1.19.3
 
 function main() {
+  checkDockerAccessible
+  
   # Install kubectl if necessary
-  if command -v kubectl version ; then
+  if command -v kubectl; then
     echo "kubectl already installed"
   else
     msg="Install kubectl ${KUBECTL_VERSION}?"
@@ -47,6 +49,16 @@ function main() {
 
   else
     installK3s
+  fi
+}
+
+function checkDockerAccessible() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker not installed" 
+    exit 1
+  elif ! docker ps >/dev/null 2>&1; then
+    echo "Docker not accessible for current user"
+    exit 1
   fi
 }
 

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -94,8 +94,9 @@ function installK3s() {
   # Renaming via k3s is not possible https://github.com/rancher/k3s/issues/1806
   tmpConfig=$(mktemp)
   sed </etc/rancher/k3s/k3s.yaml "s/: default/: ${K3S_CLUSTER_NAME}/" >"$tmpConfig"
+  # Don't fail when there is no .kube dir
+  mkdir -p ~/.kube
   KUBECONFIG=${tmpConfig}:~/.kube/config kubectl config view --flatten >~/.kube/config2 && mv ~/.kube/config2 ~/.kube/config
-
 }
 
 confirm() {

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -56,9 +56,6 @@ function checkDockerAccessible() {
   if ! command -v docker >/dev/null 2>&1; then
     echo "Docker not installed" 
     exit 1
-  elif ! docker ps >/dev/null 2>&1; then
-    echo "Docker not accessible for current user"
-    exit 1
   fi
 }
 


### PR DESCRIPTION
Following #1, I tried this on a plain ubuntu (I used multipass) and it actually failed when there was no `kubeconfig`:   
`./scripts/init-cluster.sh: line 97: /home/ubuntu/.kube/config2: No such file or directory`

```
multipass launch --name gitops 20.04
multipass shell gitops
sudo apt update && sudo apt install -y docker.io
sudo usermod -aG docker ubuntu
exit
multipass shell gitops
git clone https://github.com/cloudogu/k8s-gitops-playground
cd k8s-gitops-playground

git switch feature/init-without-kubectl

yes | scripts/init-cluster.sh
```

This should fix it.
It also checks our only prerequisite left: docker binary present and fails otherwise.