### PR TITLE
Set apiVersion to v2, so that argoCD uses Helm3 for deployment

### DIFF
--- a/applications/nginx/argocd/Chart.yaml
+++ b/applications/nginx/argocd/Chart.yaml
@@ -1,3 +1,3 @@
-apiVersion: v1
+apiVersion: v2
 version: 7.1.6
 name: nginx


### PR DESCRIPTION
Signed-off-by: Philipp Markiewka <philipp.markiewka@cloudogu.com>