### PR TITLE
Jenkins: Fix failing K8s agent builds.

### DIFF
--- a/jenkins/values.yaml
+++ b/jenkins/values.yaml
@@ -4,25 +4,29 @@ dockerClientVersion: 20.10.2
 controller:
   # to prevent the jenkins-ui-test pod being created
   testEnabled: false
-  # Use deterministic version and not "lts", which is pretty much the same as "latest".
-  # Note: When updating, check if PATH of image still matches the one listed in "containerEnv"
-  #
-  # Update (07.Mai.2021): We use the chart default since the jdk11 image has caused some problems 
-  # regarding consistency with jenkins plugins. Some plugins were not pinned to a version and needed 
-  # a constant update if there was a new version available.
-  #
-  # tag: 2.277.2-lts-jdk11
 
   serviceType: LoadBalancer
   servicePort: 80
   # Is ignored when type is LoadBalancer. For local cluster we change the service type to NodePort
   nodePort: 9090
 
-  installPlugins:
-    - kubernetes:1.29.2
-    - workflow-aggregator:2.6
-    - git:4.7.1
-    - configuration-as-code:1.51
+  # It seems that jenkins-plugin-cli 2.9.0 does not install plugin dependencies properly.
+  # So we add them explicitly here, to avoid exception such as 
+  #  Failed to load: Matrix Project Plugin (1.18)
+  #                   - Update required: JUnit Plugin (1.3) to be updated to 1.29 or higher
+  # Background: When debugging, the following command
+  #  jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugins matrix-project:1.18 --verbose
+  # returns: matrix-project has no dependencies
+  # But the following command: 
+  # jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugins matrix-project:1.18 --verbose
+  # Returns: matrix-project depends on: junit 1.50 script-security 1.77
+  # Workaround: Install the plugins that cause these problems explicitly
+  additionalPlugins:
+    - matrix-project:1.19
+    - workflow-cps:2.92
+    - pipeline-model-api:1.8.5
+    - workflow-job:2.41
+    - credentials-binding:1.26
 
   # Don't use controller for builds
   numExecutors: 0
@@ -52,7 +56,7 @@ controller:
       # We already mounted this PATH on the controller-agent. Still, "docker.inside {}" fails in pipeline?
       # Why? The docker pipeline plugin seems to set an empty environment: https://github.com/jenkinsci/docker-workflow-plugin/blob/docker-workflow-1.25/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java#L261
       # Workaround: Set the ENV in the container:
-      value: /usr/local/openjdk-8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/tmp/docker
+      value: /opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/tmp/docker
 
   customInitContainers:
     # Create Jenkins agent working dir explicitly. Otherwise it seems to be owned by root
@@ -126,7 +130,7 @@ agent:
   envVars:
     - name: PATH
       # Add /tmp/docker to the path
-      value: /usr/local/openjdk-8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/tmp/docker
+      value: /usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/tmp/docker
   volumes:
     - type: HostPath
       # See workingDir

--- a/scripts/jenkins/init-jenkins.sh
+++ b/scripts/jenkins/init-jenkins.sh
@@ -7,7 +7,9 @@ if [[ -z ${PLAYGROUND_DIR+x} ]]; then
   PLAYGROUND_DIR="$(cd "${BASEDIR}" && cd .. && cd .. && pwd)"
 fi
 
-JENKINS_HELM_CHART_VERSION=3.1.9
+# When Upgrading helm chart, also upgrade additionalPlugins in jenkins/values.yaml
+# Check for "Failed to load" in the Jenkins log and add or upgrade the plugins mentioned there appropriately.
+JENKINS_HELM_CHART_VERSION=3.3.23
 
 SET_USERNAME="admin"
 SET_PASSWORD="admin"

--- a/scripts/jenkins/init-jenkins.sh
+++ b/scripts/jenkins/init-jenkins.sh
@@ -9,6 +9,8 @@ fi
 
 # When Upgrading helm chart, also upgrade additionalPlugins in jenkins/values.yaml
 # Check for "Failed to load" in the Jenkins log and add or upgrade the plugins mentioned there appropriately.
+# In addition, check if the new helm chart version uses a newer agent.tag.
+# Note that we need JDK11 on the agents, whereas the helm chart uses JDK8 by default.
 JENKINS_HELM_CHART_VERSION=3.3.23
 
 SET_USERNAME="admin"


### PR DESCRIPTION
By upgrading to (almost) latest helm chart version and explicitly installing plugin dependencies.

Note: Didn't upgrade to latest helm chart version because it lead to errors on build, such as the following:
` Remote call to JNLP4-connect connection to jenkins-agent.default.svc.cluster.local/10.43.179.183:50000`